### PR TITLE
Added --verbose and --output options

### DIFF
--- a/packet_reordering.py
+++ b/packet_reordering.py
@@ -630,7 +630,12 @@ def re_sender(node, duration, n, bitrate, attrs, ll, lfa, lf, path):
     'path', 
     type=click.Path(exists=True)
 )
-def re_receiver(port, duration, n, bitrate, attrs, ll, lfa, lf, path):
+@click.option(
+    '--verbose/--no-verbose',
+    default=False,
+    help='Activate DEBUG level of script logs'
+)
+def re_receiver(port, duration, n, bitrate, attrs, ll, lfa, lf, path, verbose):
     # receiver, listener
     # ../srt/srt-ethouris/_build/srt-test-live srt://:4200?groupconnect=true file://con
     # TODO: groupconnect=true changed to groupconnect=1, test this additionally once
@@ -651,6 +656,10 @@ def re_receiver(port, duration, n, bitrate, attrs, ll, lfa, lf, path):
         if lfa:
             args += ['-lfa']
             args += lfa
+
+    if verbose:
+        args += ['-v']
+
     interval = calculate_interval(bitrate)
     if n is None:
         n = int(duration // interval) + 1

--- a/packet_reordering.py
+++ b/packet_reordering.py
@@ -626,17 +626,22 @@ def re_sender(node, duration, n, bitrate, attrs, ll, lfa, lf, path):
     type=click.Path(),
     help='File to send logs to'
 )
+@click.option(
+    '--output', 
+    type=click.Path(exists=False),
+    help='File to send output to'
+)
 @click.argument(
     'path', 
     type=click.Path(exists=True)
 )
 @click.option(
     '--verbose',
-	type=click.Path(exists=False),
+    type=click.Path(exists=False),
     default='',
     help='Activate VERBOSE log'
 )
-def re_receiver(port, duration, n, bitrate, attrs, ll, lfa, lf, path, verbose):
+def re_receiver(port, duration, n, bitrate, attrs, ll, lfa, lf, output, path, verbose):
     # receiver, listener
     # ../srt/srt-ethouris/_build/srt-test-live srt://:4200?groupconnect=true file://con
     # TODO: groupconnect=true changed to groupconnect=1, test this additionally once
@@ -644,10 +649,15 @@ def re_receiver(port, duration, n, bitrate, attrs, ll, lfa, lf, path, verbose):
     srt_str = f'srt://:{port}'
     if attrs:
         srt_str += f'?{attrs}'
+    if output == None:
+        output_path = 'file://con'
+    else:
+        output_path = output
+
     args = [
         f'{path}',
         srt_str,
-        'file://con',
+        output_path,
     ]
     if lf:
         args += [

--- a/packet_reordering.py
+++ b/packet_reordering.py
@@ -631,9 +631,10 @@ def re_sender(node, duration, n, bitrate, attrs, ll, lfa, lf, path):
     type=click.Path(exists=True)
 )
 @click.option(
-    '--verbose/--no-verbose',
-    default=False,
-    help='Activate DEBUG level of script logs'
+    '--verbose',
+	type=click.Path(exists=False),
+    default='',
+    help='Activate VERBOSE log'
 )
 def re_receiver(port, duration, n, bitrate, attrs, ll, lfa, lf, path, verbose):
     # receiver, listener
@@ -657,8 +658,9 @@ def re_receiver(port, duration, n, bitrate, attrs, ll, lfa, lf, path, verbose):
             args += ['-lfa']
             args += lfa
 
-    if verbose:
+    if verbose != '':
         args += ['-v']
+        args += [f'./{verbose}']
 
     interval = calculate_interval(bitrate)
     if n is None:


### PR DESCRIPTION
Note: --verbose works only with a version of `srt-test-live` that supports `-v ./filename` specification.